### PR TITLE
build: add custom Scoop bucket workflow

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -114,14 +114,33 @@ winget uninstall --id TX230.winproc-tui -e
 
 winget は公式 GitHub Release の zip をダウンロードし、`winproc-tui` コマンドを登録します。追加のランタイムは不要です。
 
+### Scoop（TX230 Bucket）でインストールする
+
+```powershell
+scoop bucket add tx230 https://github.com/TX230/scoop-bucket
+scoop install tx230/winproc-tui
+```
+
+インストール後は、任意のディレクトリから `winproc-tui` で起動できます。更新とアンインストールは次のコマンドで行います。
+
+```powershell
+scoop update
+scoop update winproc-tui
+scoop uninstall winproc-tui
+```
+
+通常のアンインストールでは `winproc-tui.toml` が保持されます。設定も削除する場合は `scoop uninstall --purge winproc-tui` を使用します。
+
+TX230 Bucket は公式 GitHub Release の zip をダウンロードし、SHA256 を検証して `winproc-tui` コマンドを登録します。追加のランタイムは不要です。
+
 ### zip を展開して使う
 
 [GitHub Releases](https://github.com/TX230/winproc-tui/releases) から入手します。
 ダウンロードした zip を任意のフォルダに展開し、`winproc-tui.exe` を実行してください。追加のランタイムやインストーラは不要です。
-zip には `winproc-tui.exe` と `LICENSE` のみが含まれます。README などのドキュメントは GitHub で公開し、配布zipには含めません。
+現行のパッケージ作成手順では、zip に `winproc-tui.exe` と `LICENSE` のみを含めます。README などのドキュメントは GitHub で公開し、配布zipには含めません。v0.4.0 のzipはこの方針より前に公開されたため、README、`assets/`、`docs/`も含まれます。
 `winproc-tui.toml` は同梱されません。ファイルがない状態では既定値で起動し、正常終了時に実行ファイルと同じディレクトリへ作成されます。
 
-公式のビルド済みバイナリは [TX230/winproc-tui Releases](https://github.com/TX230/winproc-tui/releases) からのみ公開します。winget もこの Release のバイナリを使用します。第三者によるコピー、ミラー、改変リポジトリで配布されるバイナリは公式ビルドではありません。
+公式のビルド済みバイナリは [TX230/winproc-tui Releases](https://github.com/TX230/winproc-tui/releases) からのみ公開します。winget と [TX230 Scoop Bucket](https://github.com/TX230/scoop-bucket) もこの Release のバイナリを使用します。第三者によるコピー、ミラー、改変リポジトリで配布されるバイナリは公式ビルドではありません。
 
 Release から zip と対応する `.zip.sha256` ファイルをダウンロードします。zip の SHA256 ハッシュ値を計算するコマンドは以下のとおりです。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -18,14 +18,15 @@ _追跡、表示の一時停止、A/B 比較を使用してプロセスのプラ
 
 ### 1. 起動する
 
-winget を使用できる環境では、次のコマンドでインストールして起動できます。
+Scoop を使用できる環境では、TX230 Bucket からインストールして起動できます。
 
 ```powershell
-winget install --id TX230.winproc-tui -e
+scoop bucket add tx230 https://github.com/TX230/scoop-bucket
+scoop install tx230/winproc-tui
 winproc-tui
 ```
 
-または、[GitHub Releases](https://github.com/TX230/winproc-tui/releases) から zip をダウンロードして展開し、`winproc-tui.exe` を実行します。追加のランタイムは不要です。
+winget は現在申請中であり、まだ `TX230.winproc-tui` をインストールできません。または、[GitHub Releases](https://github.com/TX230/winproc-tui/releases) から zip をダウンロードして展開し、`winproc-tui.exe` を実行します。追加のランタイムは不要です。
 
 画面上部にはシステム全体の RAM / VRAM、ネットワーク / ディスク、CPU 使用率が表示され、`PROCESSES` パネルには実行中のプロセスが並びます。`Tab` / `Shift+Tab` でパネルを移動し、方向キーで行やカラムを選択します。
 
@@ -97,22 +98,9 @@ Windows 専用です。Linux / macOS など他のプラットフォームには�
 
 ## ビルド済みバイナリを使う
 
-### winget でインストールする
+### winget（申請中・現在はインストール不可）
 
-```powershell
-winget install --id TX230.winproc-tui -e
-```
-
-インストール後は、任意のディレクトリから `winproc-tui` で起動できます。更新とアンインストールは次のコマンドで行います。
-
-```powershell
-winget upgrade --id TX230.winproc-tui -e
-winget uninstall --id TX230.winproc-tui -e
-```
-
-設定を含む portable パッケージのディレクトリをすべて削除する場合は、アンインストール時に `--purge` を追加します。
-
-winget は公式 GitHub Release の zip をダウンロードし、`winproc-tui` コマンドを登録します。追加のランタイムは不要です。
+winget は現在 [winget-pkgs への登録を申請中](https://github.com/microsoft/winget-pkgs/pull/406136) です。申請はまだ審査・マージされていないため、`TX230.winproc-tui` を winget からダウンロードまたはインストールすることはできません。現時点では、以下の Scoop または GitHub Releases を使用してください。
 
 ### Scoop（TX230 Bucket）でインストールする
 
@@ -140,7 +128,7 @@ TX230 Bucket は公式 GitHub Release の zip をダウンロードし、SHA256 
 現行のパッケージ作成手順では、zip に `winproc-tui.exe` と `LICENSE` のみを含めます。README などのドキュメントは GitHub で公開し、配布zipには含めません。v0.4.0 のzipはこの方針より前に公開されたため、README、`assets/`、`docs/`も含まれます。
 `winproc-tui.toml` は同梱されません。ファイルがない状態では既定値で起動し、正常終了時に実行ファイルと同じディレクトリへ作成されます。
 
-公式のビルド済みバイナリは [TX230/winproc-tui Releases](https://github.com/TX230/winproc-tui/releases) からのみ公開します。winget と [TX230 Scoop Bucket](https://github.com/TX230/scoop-bucket) もこの Release のバイナリを使用します。第三者によるコピー、ミラー、改変リポジトリで配布されるバイナリは公式ビルドではありません。
+公式のビルド済みバイナリは [TX230/winproc-tui Releases](https://github.com/TX230/winproc-tui/releases) からのみ公開します。現在利用できる [TX230 Scoop Bucket](https://github.com/TX230/scoop-bucket) は、この Release のバイナリを使用します。申請中の winget パッケージも、承認後は同じ Release のバイナリを使用します。第三者によるコピー、ミラー、改変リポジトリで配布されるバイナリは公式ビルドではありません。
 
 Release から zip と対応する `.zip.sha256` ファイルをダウンロードします。zip の SHA256 ハッシュ値を計算するコマンドは以下のとおりです。
 

--- a/README.md
+++ b/README.md
@@ -114,13 +114,32 @@ To remove the entire portable package directory, including its configuration, ad
 
 winget downloads the zip from the official GitHub Release and registers the `winproc-tui` command. No additional runtime is required.
 
+### Install with Scoop (TX230 Bucket)
+
+```powershell
+scoop bucket add tx230 https://github.com/TX230/scoop-bucket
+scoop install tx230/winproc-tui
+```
+
+After installation, run `winproc-tui` from any directory. Use these commands to update or uninstall it:
+
+```powershell
+scoop update
+scoop update winproc-tui
+scoop uninstall winproc-tui
+```
+
+A normal uninstall preserves `winproc-tui.toml`. To remove the persisted configuration as well, use `scoop uninstall --purge winproc-tui`.
+
+The TX230 Bucket downloads the zip from the official GitHub Release, verifies its SHA256 hash, and registers the `winproc-tui` command. No additional runtime is required.
+
 ### Extract the zip manually
 
 Download the zip from [GitHub Releases](https://github.com/TX230/winproc-tui/releases), extract it to any folder, and run `winproc-tui.exe`. No additional runtime or installer is required.
-The zip contains only `winproc-tui.exe` and `LICENSE`. Documentation such as the README remains on GitHub and is not included in the distribution archive.
+The current packaging workflow includes only `winproc-tui.exe` and `LICENSE`. Documentation such as the README remains on GitHub and is not included in new distribution archives. The v0.4.0 zip predates this policy and also contains the README files, `assets/`, and `docs/`.
 `winproc-tui.toml` is not prepackaged. The application starts with defaults when the file is absent and creates it next to the executable after a successful run.
 
-Official release binaries are published only from [TX230/winproc-tui Releases](https://github.com/TX230/winproc-tui/releases). winget uses the same Release binaries.
+Official release binaries are published only from [TX230/winproc-tui Releases](https://github.com/TX230/winproc-tui/releases). winget and the [TX230 Scoop Bucket](https://github.com/TX230/scoop-bucket) use the same Release binaries.
 Binaries from third-party copies, mirrors, or modified repositories are not official builds.
 
 Download both the zip and its corresponding `.zip.sha256` file from the Release. Use these PowerShell commands to calculate the zip's SHA256 hash and display the published value:

--- a/README.md
+++ b/README.md
@@ -18,14 +18,15 @@ _Example investigation of a process's private memory using tracking, display pau
 
 ### 1. Launch the App
 
-If winget is available, install and launch the app with:
+If Scoop is available, install and launch the app from the TX230 Bucket:
 
 ```powershell
-winget install --id TX230.winproc-tui -e
+scoop bucket add tx230 https://github.com/TX230/scoop-bucket
+scoop install tx230/winproc-tui
 winproc-tui
 ```
 
-Alternatively, download the zip from [GitHub Releases](https://github.com/TX230/winproc-tui/releases), extract it, and run `winproc-tui.exe`. No additional runtime is required.
+The winget registration is currently pending review, so `TX230.winproc-tui` cannot be installed through winget yet. Alternatively, download the zip from [GitHub Releases](https://github.com/TX230/winproc-tui/releases), extract it, and run `winproc-tui.exe`. No additional runtime is required.
 
 The upper panels show system-wide RAM / VRAM, network / disk activity, and CPU usage. The `PROCESSES` panel lists running processes. Use `Tab` / `Shift+Tab` to move between panels and the arrow keys to select rows and columns.
 
@@ -97,22 +98,9 @@ Administrator privileges are not required for normal monitoring. Some metrics an
 
 ## Use a Prebuilt Binary
 
-### Install with winget
+### winget (pending; installation unavailable)
 
-```powershell
-winget install --id TX230.winproc-tui -e
-```
-
-After installation, run `winproc-tui` from any directory. Use these commands to upgrade or uninstall it:
-
-```powershell
-winget upgrade --id TX230.winproc-tui -e
-winget uninstall --id TX230.winproc-tui -e
-```
-
-To remove the entire portable package directory, including its configuration, add `--purge` when uninstalling.
-
-winget downloads the zip from the official GitHub Release and registers the `winproc-tui` command. No additional runtime is required.
+The winget package is currently [pending submission to winget-pkgs](https://github.com/microsoft/winget-pkgs/pull/406136). The submission has not been reviewed and merged yet, so `TX230.winproc-tui` cannot be downloaded or installed through winget. Use Scoop below or GitHub Releases for now.
 
 ### Install with Scoop (TX230 Bucket)
 
@@ -139,7 +127,7 @@ Download the zip from [GitHub Releases](https://github.com/TX230/winproc-tui/rel
 The current packaging workflow includes only `winproc-tui.exe` and `LICENSE`. Documentation such as the README remains on GitHub and is not included in new distribution archives. The v0.4.0 zip predates this policy and also contains the README files, `assets/`, and `docs/`.
 `winproc-tui.toml` is not prepackaged. The application starts with defaults when the file is absent and creates it next to the executable after a successful run.
 
-Official release binaries are published only from [TX230/winproc-tui Releases](https://github.com/TX230/winproc-tui/releases). winget and the [TX230 Scoop Bucket](https://github.com/TX230/scoop-bucket) use the same Release binaries.
+Official release binaries are published only from [TX230/winproc-tui Releases](https://github.com/TX230/winproc-tui/releases). The currently available [TX230 Scoop Bucket](https://github.com/TX230/scoop-bucket) uses these Release binaries. After approval, the pending winget package will use the same Release binaries.
 Binaries from third-party copies, mirrors, or modified repositories are not official builds.
 
 Download both the zip and its corresponding `.zip.sha256` file from the Release. Use these PowerShell commands to calculate the zip's SHA256 hash and display the published value:

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -233,6 +233,45 @@ Open the draft release in GitHub and confirm:
 
 After confirming the draft, publish it from the GitHub Releases page.
 
+## Scoop Bucket Publication
+
+The custom Scoop bucket is published from `TX230/scoop-bucket`. Its `bucket/winproc-tui.json` manifest downloads the versioned Windows x64 zip directly from this repository's GitHub Release, verifies its SHA-256 hash, registers the `winproc-tui` command, and persists `winproc-tui.toml`.
+
+Publish and verify the GitHub Release before updating the Scoop manifest. Never use a `latest` asset URL. Set the manifest `version`, version-specific `url`, and `hash` from the published asset, and do not replace an asset after a manifest refers to its URL.
+
+The manifest keeps the release zip unchanged. It uses `pre_install` to create an empty `winproc-tui.toml` only when no persisted file exists, then declares the file in `persist`. Do not add a preset config to the release zip.
+
+After updating the manifest, confirm that Scoop detects the intended release:
+
+```powershell
+& "$(scoop prefix scoop)\bin\checkver.ps1" `
+  -App winproc-tui `
+  -Dir <scoop-bucket>\bucket `
+  -ThrowError
+```
+
+Run the bucket tests and perform a clean lifecycle check:
+
+```powershell
+scoop bucket add tx230 https://github.com/TX230/scoop-bucket
+scoop install tx230/winproc-tui
+& "$(scoop prefix winproc-tui)\winproc-tui.exe" --version
+scoop uninstall winproc-tui
+scoop install tx230/winproc-tui
+scoop uninstall --purge winproc-tui
+```
+
+Confirm at least:
+
+- The manifest passes the Scoop schema and bucket tests.
+- The downloaded zip passes its SHA-256 check.
+- The installed executable reports the intended version.
+- The shim is created and removed correctly.
+- A normal uninstall preserves `winproc-tui.toml`.
+- Reinstallation reuses the persisted config.
+- `--purge` removes the persisted config.
+- `checkver` and `autoupdate` resolve the versioned Release asset naming convention.
+
 ## Windows Package Manager Publication
 
 The winget package identifier is `TX230.winproc-tui`. Its portable manifest downloads the versioned Windows x64 zip directly from this repository's GitHub Release and registers the `winproc-tui` command.

--- a/scripts/package-release.ps1
+++ b/scripts/package-release.ps1
@@ -143,6 +143,11 @@ try {
 
     Write-Host "Created package: $ZipPath"
     Write-Host "Created checksum: $Sha256Path"
+    Write-Host "After publishing the GitHub Release, update the Scoop manifest:"
+    Write-Host "  Bucket: https://github.com/TX230/scoop-bucket"
+    Write-Host "  Version: $Version"
+    Write-Host "  URL: https://github.com/TX230/winproc-tui/releases/download/v$Version/$ZipName"
+    Write-Host "  SHA256: $($hash.Hash.ToLowerInvariant())"
 }
 finally {
     Pop-Location


### PR DESCRIPTION
## What changed

- document installation, update, uninstall, and purge through `TX230/scoop-bucket` in Japanese and English
- document the Scoop manifest release workflow and lifecycle checks
- print the Scoop manifest version, release URL, and SHA-256 after release packaging
- clarify that the published v0.4.0 archive predates the current runtime-only package policy

## Why

Make the TX230-managed Scoop bucket discoverable and keep future Scoop manifest updates aligned with the immutable GitHub Release asset.

## Validation

- `cargo test` (420 passed, 1 ignored manual performance probe)
- `cargo build --release`
- `scripts/package-release.ps1 -Version 0.4.0 -SkipTests -SkipBuild`
- generated package entries: exactly `winproc-tui.exe` and `LICENSE`
- Scoop manifest schema and lifecycle validation completed in `TX230/scoop-bucket` PR #1
